### PR TITLE
Ignore GnuWin32 helper utilities (e.g. gzip, tar)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.vdi
 *.mf
 *.tar.gz
+usr/bin/


### PR DESCRIPTION
Requires the following GNU Win32 utilities:

1. `gzip` (v1.3.12)
2. `tar` (v1.13-1)
3. `libintl` (v0.11.5)
4. `libiconv` (v1.8-1)